### PR TITLE
Add toggle comment

### DIFF
--- a/QL.sublime-syntax
+++ b/QL.sublime-syntax
@@ -43,6 +43,8 @@ contexts:
       scope: variable.language.dont-care.ql
     - match: '::'
       scope: punctuation.accessor
+    - match: '\b[0-9A-Za-z_]\b'
+      scope: variable.id_character
 
     # Add highlight mismatching brackets
     - match: \(\{

--- a/ql.sublime-settings
+++ b/ql.sublime-settings
@@ -1,0 +1,8 @@
+// These settings override both User and Default settings for the ql syntax
+{
+    // The number of spaces a tab is considered equal to
+    "tab_size": 2,
+
+    // Set to true to insert spaces when tab is pressed
+    "translate_tabs_to_spaces": true,
+}

--- a/ql.tmPreferences
+++ b/ql.tmPreferences
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Comments</string>
+    <key>scope</key>
+    <string>source.QL</string>
+    <key>settings</key>
+    <dict>
+        <key>shellVariables</key>
+        <array>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START</string>
+                <key>value</key>
+                <string>// </string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START_2</string>
+                <key>value</key>
+                <string>/*</string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_END_2</string>
+                <key>value</key>
+                <string>*/</string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
It was bothering me that I couldn't toggle comments with `Ctrl+/` and `Ctrl+Shift+/` so I worked out how to change it!

(Not done `qldoc` though.)

https://help.semmle.com/QL/ql-handbook/lexical-syntax.html